### PR TITLE
Support for cloudinary file upload options: `tag` and `folder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ You'll need to create a upload preset in cloudinary.  I belive the following opt
       "CloudinaryPreset": "preset"
     }
 
+# File Upload Options
+Cloudinary allows a number of [file upload options](http://cloudinary.com/documentation/node_image_upload#all_upload_options), as documented in their nodejs API. A few of these options are supported for now.
+
+### tags (optional)
+A tag name or an array with a list of tag names to assign to the uploaded image.
+
+    Slingshot.createDirective('videos', Slingshot.Cloudinary, {
+        authorize() {...},
+        key() {...},
+        tags: ['tag1', 'tag2']
+    });
+
+### folder (optional)
+An optional folder name where the uploaded resource will be stored. The public ID contains the full path of the uploaded resource, including the folder name.
+
+    Slingshot.createDirective('videos', Slingshot.Cloudinary, {
+        authorize() {...},
+        key() {...},
+        folder: myFolder
+    });
 
 # Todo
 
@@ -52,3 +72,4 @@ There is still work to be done.  Pull requests welcome.
 
 - [ ] Improve handling of video, image, and raw upload types.
 - [ ] Check that public_id is checked using the signature.
+- [ ] Implement all the file upload options supported by cloudinary

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'jimmiebtlr:slingshot-cloudinary',
-  version: '0.0.6',
+  version: '0.0.6_1',
   summary: 'Cloudinary storage implementation for edgee:slingshot.',
   git: 'https://github.com/jimmiebtlr/meteor-slingshot-cloudinary',
   documentation: 'README.md'

--- a/server.js
+++ b/server.js
@@ -8,6 +8,9 @@ Slingshot.Cloudinary = {
     CloudinaryPreset: String,
 
     key: Match.OneOf(String, Function),
+
+    tags: Match.Optional(Match.OneOf(String, [String])),
+    folder: Match.Optional(String),
   },
 
   directiveDefault: Object.assign({}, {
@@ -71,6 +74,10 @@ Slingshot.Cloudinary = {
       // isn't in this lib.
       resource_type: this.resourceType(file.type),
     });
+
+    // Assign optional cloudinary options
+    if (_.has(directive, 'tags')) options.tags = directive.tags;
+    if (_.has(directive, 'folder')) options.folder = directive.folder;
 
     const signature = Cloudinary.uploader.direct_upload('', options);
 


### PR DESCRIPTION
Cloudinary allows a number of [file upload options](http://cloudinary.com/documentation/node_image_upload#all_upload_options), as documented in their nodejs API. Support for `tags` and `folder` introduced.
