### PR TITLE
Get metaContext in 'upload' and pass parameters to the directive key()

### DIFF
--- a/server.js
+++ b/server.js
@@ -20,23 +20,14 @@ Slingshot.Cloudinary = {
     CloudinaryPreset: Meteor.settings.CloudinaryPreset,
   }),
 
-  isImage(mime) {
-    return _.contains(['image/jpeg','image/jpg', 'image/png', 'image/svg', 'application/pdf'], mime);
-  },
+  // Determined by mime types 'image/*' and 'video/*'
+  resourceType(mimeType) {
+    const mimeSplit = mimeType.split('/');
 
-  isVideo(type) {
-    return _.contains(
-      ['video/mp4'],
-      type
-    );
-  },
-
-  resourceType(type) {
-    return this.isImage(type)
-      ? 'image'
-      : this.isVideo(type)
-        ? 'video'
-        : 'raw';
+    if (_.contains(['image', 'video'], mimeSplit[0]))
+      return mimeSplit[0];
+    else
+      return 'raw';
   },
 
   upload: function upload(method, directive, file, meta) {

--- a/server.js
+++ b/server.js
@@ -39,9 +39,9 @@ Slingshot.Cloudinary = {
         : 'raw';
   },
 
-  upload: function upload(method, directive, file) {
+  upload: function upload(method, directive, file, meta) {
     const { CloudinaryCloudName } = directive;
-    const publicId = directive.key();
+    const publicId = directive.key(method, file, meta);
 
     // Cloudinary's node lib supplies most of what we need.
     const cloudinarySign = this.cloudinarySign(publicId, directive, file);


### PR DESCRIPTION
This update matches the original slingshot library's 'upload' method functionality.